### PR TITLE
Potential fix for code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,9 +10,9 @@ def get_utente():
     db_connection = sqlite3.connect('database.db')
     cursor = db_connection.cursor()
 
-    # Vulnerabilità SQL Injection (String formatting)
-    query = "SELECT nome, email FROM utenti WHERE id = {}".format(utente_id)
-    cursor.execute(query)
+    # Utilizzo di query parametrizzata per prevenire SQL Injection
+    query = "SELECT nome, email FROM utenti WHERE id = ?"
+    cursor.execute(query, (utente_id,))
     utente = cursor.fetchone()
 
     db_connection.close()


### PR DESCRIPTION
Potential fix for [https://github.com/amusarra/codeql-checkov-quickstart/security/code-scanning/2](https://github.com/amusarra/codeql-checkov-quickstart/security/code-scanning/2)

To fix the problem, we should use parameterized queries instead of string formatting to construct the SQL query. This approach ensures that user input is properly escaped and prevents SQL injection attacks.

- Replace the string formatting in the SQL query with a parameterized query.
- Use placeholders (`?`) in the SQL query and pass the user input as a parameter to the `execute` method.
- Ensure that the `utente_id` is passed as a tuple to the `execute` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
